### PR TITLE
Partially support Facebook's limited data mode

### DIFF
--- a/ParseFacebookUtils/ParseFacebookUtils/Internal/AuthenticationProvider/iOS/PFFacebookMobileAuthenticationProvider.m
+++ b/ParseFacebookUtils/ParseFacebookUtils/Internal/AuthenticationProvider/iOS/PFFacebookMobileAuthenticationProvider.m
@@ -45,9 +45,14 @@
                                                                      fromViewComtroller:(UIViewController *)viewController {
     
     NSArray *permissions = [readPermissions arrayByAddingObjectsFromArray:publishPermissions];
-                                                                       
+
+    // This is enough for combyne's use-case. Extended permissions (including publish permissions)
+    // are ignored, but we won't pass them in the first place.
+    FBSDKLoginConfiguration *configuration = [[FBSDKLoginConfiguration alloc] initWithPermissions:readPermissions
+                                                                                         tracking:FBSDKLoginTrackingLimited];
+
     BFTaskCompletionSource *taskCompletionSource = [BFTaskCompletionSource taskCompletionSource];
-    FBSDKLoginManagerLoginResultBlock resultHandler = ^(FBSDKLoginManagerLoginResult *result, NSError *error) {
+    FBSDKLoginManagerLoginResultBlock completion = ^(FBSDKLoginManagerLoginResult *result, NSError *error) {
         if (result.isCancelled) {
             [taskCompletionSource cancel];
         } else if (error) {
@@ -57,7 +62,7 @@
         }
     };
     
-    [self.loginManager logInWithPermissions:permissions fromViewController:viewController handler:resultHandler];
+    [self.loginManager logInFromViewController:viewController configuration:configuration completion:completion];
     
     return taskCompletionSource.task;
 }

--- a/ParseFacebookUtils/ParseFacebookUtils/Internal/AuthenticationProvider/iOS/PFFacebookMobileAuthenticationProvider.m
+++ b/ParseFacebookUtils/ParseFacebookUtils/Internal/AuthenticationProvider/iOS/PFFacebookMobileAuthenticationProvider.m
@@ -43,9 +43,6 @@
 - (BFTask<NSDictionary<NSString *, NSString *>*> *)authenticateAsyncWithReadPermissions:(nullable NSArray<NSString *> *)readPermissions
                                                                      publishPermissions:(nullable NSArray<NSString *> *)publishPermissions
                                                                      fromViewComtroller:(UIViewController *)viewController {
-    
-    NSArray *permissions = [readPermissions arrayByAddingObjectsFromArray:publishPermissions];
-
     // This is enough for combyne's use-case. Extended permissions (including publish permissions)
     // are ignored, but we won't pass them in the first place.
     FBSDKLoginConfiguration *configuration = [[FBSDKLoginConfiguration alloc] initWithPermissions:readPermissions
@@ -58,7 +55,8 @@
         } else if (error) {
             taskCompletionSource.error = error;
         } else {
-            taskCompletionSource.result = [PFFacebookPrivateUtilities userAuthenticationDataFromAccessToken:result.token];
+            FBSDKAuthenticationToken *token = FBSDKAuthenticationToken.currentAuthenticationToken;
+            taskCompletionSource.result = [PFFacebookPrivateUtilities userAuthenticationDataFromAuthenticationToken:token];
         }
     };
     
@@ -75,7 +73,9 @@
     if (!authData) {
         [self.loginManager logOut];
     }
-    return [super restoreAuthenticationWithAuthData:authData];
+
+    // With limited login, there's no access token to restore since Graph API queries are impossible.
+    return YES;
 }
 
 @end

--- a/ParseFacebookUtils/ParseFacebookUtils/Internal/PFFacebookPrivateUtilities.h
+++ b/ParseFacebookUtils/ParseFacebookUtils/Internal/PFFacebookPrivateUtilities.h
@@ -29,6 +29,9 @@ NS_ASSUME_NONNULL_BEGIN
 + (NSDictionary *)userAuthenticationDataWithFacebookUserId:(NSString *)userId
                                                accessToken:(NSString *)accessToken
                                             expirationDate:(NSDate *)expirationDate;
++ (NSDictionary *)userAuthenticationDataWithFacebookUserId:(NSString *)userId
+                                       authenticationToken:(NSString *)authenticationToken;
++ (nullable NSDictionary *)userAuthenticationDataFromAuthenticationToken:(FBSDKAuthenticationToken *)token;
 + (nullable NSDictionary *)userAuthenticationDataFromAccessToken:(FBSDKAccessToken *)token;
 
 + (nullable FBSDKAccessToken *)facebookAccessTokenFromUserAuthenticationData:(nullable NSDictionary<NSString *, NSString *> *)authData;

--- a/ParseFacebookUtils/ParseFacebookUtils/Internal/PFFacebookPrivateUtilities.m
+++ b/ParseFacebookUtils/ParseFacebookUtils/Internal/PFFacebookPrivateUtilities.m
@@ -33,6 +33,17 @@
               @"expiration_date" : [[NSDateFormatter pffb_preciseDateFormatter] stringFromDate:expirationDate] };
 }
 
++ (NSDictionary *)userAuthenticationDataWithFacebookUserId:(NSString *)userId
+                                       authenticationToken:(NSString *)authenticationToken {
+    // The expiration date is provided for compatibility reasons but is, in fact, ignored.
+    // With Limited Login, the authentication token is provided through "token" instead of "access_token".
+    NSDate* expirationDate = [[NSDate new] dateByAddingTimeInterval:20];
+
+    return @{ @"id" : userId,
+              @"token" : authenticationToken,
+              @"expiration_date" : [[NSDateFormatter pffb_preciseDateFormatter] stringFromDate:expirationDate] };
+}
+
 + (nullable NSDictionary *)userAuthenticationDataFromAccessToken:(FBSDKAccessToken *)token {
     if (!token.userID || !token.tokenString || !token.expirationDate) {
         return nil;
@@ -41,6 +52,18 @@
     return [self userAuthenticationDataWithFacebookUserId:token.userID
                                               accessToken:token.tokenString
                                            expirationDate:token.expirationDate];
+}
+
++ (nullable NSDictionary *)userAuthenticationDataFromAuthenticationToken:(FBSDKAuthenticationToken *)token {
+    NSString *userID = FBSDKProfile.currentProfile.userID;
+    NSString *tokenString = token.tokenString;
+
+    if (!userID || !tokenString) {
+        return nil;
+    }
+
+    return [self userAuthenticationDataWithFacebookUserId:userID
+                                      authenticationToken:tokenString];
 }
 
 + (nullable FBSDKAccessToken *)facebookAccessTokenFromUserAuthenticationData:(nullable NSDictionary<NSString *, NSString *> *)authData {


### PR DESCRIPTION
These changes basically replace the normal login strategy with the limited one. It's absolutely not generic and it's only fitting our needs until the Parse community figure out how they want to handle it.